### PR TITLE
Add unit tests for vxlan utilities and improve IP validation

### DIFF
--- a/modular architecture/vxlan_utils.py
+++ b/modular architecture/vxlan_utils.py
@@ -382,4 +382,6 @@ def extract_numbers_from_string(text: str) -> List[int]:
 def is_valid_ip(ip: str) -> bool:
     """Validate IP address format"""
     pattern = r'^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$'
-    return bool(re.match(pattern, ip))
+    if not re.match(pattern, ip):
+        return False
+    return all(0 <= int(octet) <= 255 for octet in ip.split('.'))

--- a/tests/test_vxlan_utils.py
+++ b/tests/test_vxlan_utils.py
@@ -1,0 +1,63 @@
+import os
+import sys
+
+# Add the path to the 'modular architecture' directory so modules can be imported
+PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
+MODULE_DIR = os.path.join(PROJECT_ROOT, 'modular architecture')
+if MODULE_DIR not in sys.path:
+    sys.path.insert(0, MODULE_DIR)
+
+from vxlan_utils import (
+    VXLANParser,
+    VXLANValidator,
+    safe_int_conversion,
+    format_mac_address,
+    calculate_percentage,
+    extract_numbers_from_string,
+    is_valid_ip,
+)
+from vxlan_config import CONFIG
+
+
+def test_safe_int_conversion():
+    assert safe_int_conversion('10') == 10
+    assert safe_int_conversion('invalid', default=5) == 5
+
+
+def test_format_mac_address():
+    assert format_mac_address('AA:BB:CC:DD:EE:FF') == 'aabb.ccdd.eeff'
+
+
+def test_calculate_percentage():
+    assert calculate_percentage(50, 200) == 25.0
+    assert calculate_percentage(5, 0) == 0.0
+
+
+def test_extract_numbers_from_string():
+    assert extract_numbers_from_string('abc123def45') == [123, 45]
+
+
+def test_is_valid_ip():
+    assert is_valid_ip('192.168.0.1') is True
+    assert is_valid_ip('999.999.999.999') is False
+
+
+def test_parse_nxos_version():
+    sample_output = 'system:    version 9.3(5)'
+    assert VXLANParser.parse_nxos_version(sample_output) == 9.3
+
+
+def test_validate_required_features():
+    features = {
+        CONFIG.features.vn_segment_feature: 'enabled',
+        CONFIG.features.nv_overlay_feature: 'enabled',
+    }
+    valid, missing = VXLANValidator.validate_required_features(features)
+    assert valid is True
+    assert missing == []
+
+    features = {}
+    valid, missing = VXLANValidator.validate_required_features(features)
+    assert valid is False
+    assert CONFIG.features.vn_segment_feature in missing
+    assert CONFIG.features.nv_overlay_feature in missing


### PR DESCRIPTION
## Summary
- add pytest suite covering vxlan utility helpers
- harden is_valid_ip with octet range validation

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68b196f138c88324a45293a2f5448203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved IPv4 validation to reject addresses with out-of-range octets, ensuring only properly formed addresses are accepted.

- Tests
  - Added comprehensive unit tests covering:
    - Safe integer conversion with fallbacks.
    - MAC address normalization and formatting.
    - Percentage calculation, including zero-denominator handling.
    - Number extraction from mixed strings.
    - IPv4 validation for valid and invalid inputs.
    - Version parsing from platform output.
    - Verification of required feature flags, including enabled-state checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->